### PR TITLE
Smaller image with alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM debian:jessie
+FROM alpine:3.1
 
-RUN apt-get update \
-	&& apt-get install -y mercurial \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk --update add mercurial openssh bash
+
+RUN mkdir -p /etc/mercurial
 
 ADD run.sh /run.sh
 RUN echo "    IdentityFile /bazooka-key" >> /etc/ssh/ssh_config


### PR DESCRIPTION
Before

```
> docker images
REPOSITORY              TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
bazooka/scm-hg          latest              05a1746fc95e        28 seconds ago      181.2 MB
```

After 

```
> docker images
REPOSITORY              TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
bazooka/scm-hg          latest              ffbb03e7e255        36 minutes ago      52.95 MB
```
